### PR TITLE
update to pack routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Before you begin, ensure that you have met the following requirements:
 
 **Event Breakers**
 
-IBM MQ logs will require a Timestamp event breaker type.  RabbitMQ and ActiveMQ can use the default Break on Newline, however if you would like to keep logs consistent, all can be broken with a Timestamp Event Breaker.
+IBM MQ logs require event breaking that does not use traditional new line breakers in Syslog messages. If you are sending via TCP, you may be able to configure using the Raw TCP source to add a custom event breaker on ingest.  RabbitMQ and ActiveMQ can use the default Break on Newline.
 
 **IBM MQ Note**
 

--- a/default/pipelines/IBM_MQ/conf.yml
+++ b/default/pipelines/IBM_MQ/conf.yml
@@ -187,7 +187,7 @@ functions:
           rate: 100
     description: "[CUSTOMIZE] Retain 1 out of every 100 info level logs"
   - id: suppress
-    filter: Error_Code.includes('I')
+    filter: Error_Code.endsWith('I')
     disabled: true
     conf:
       allow: 1

--- a/default/pipelines/route.yml
+++ b/default/pipelines/route.yml
@@ -8,7 +8,7 @@ routes:
     pipeline: Rabbit_MQ
     description: Processing of RabbitMQ logs
     clones: []
-    filter: _raw.startsWith(/\d+-\d+-\d+\s\d+:\d+:\d+.\d+ \[/)
+    filter: /\d+-\d+-\d+\s\d+:\d+:\d+.\d+ \[/.test(_raw)
     output: default
   - id: KsssLY
     name: IBM_MQ
@@ -17,7 +17,7 @@ routes:
     pipeline: IBM_MQ
     description: Processing of IBM MQ (formerly Websphere) logs
     clones: []
-    filter: _raw.startsWith(/\d+\/\d+\/\d+\s\d+:\d+:\d+\s\-\sProcess\s\(/)
+    filter: /\d+\/\d+\/\d+\s\d+:\d+:\d+\s\-\sProcess\s\(/.test(_raw)
     output: default
   - id: xY2E3N
     name: Active_MQ
@@ -26,7 +26,7 @@ routes:
     pipeline: Active_MQ
     description: Processing of Apache ActiveMQ logs
     clones: []
-    filter: _raw.startsWith(/\d+\-\d+\-\d+\s\d+:\d+:\d+,\d+\s\|/)
+    filter: /\d+\-\d+\-\d+\s\d+:\d+:\d+,\d+\s\|/.test(_raw)
     output: default
   - id: default
     name: default


### PR DESCRIPTION
This fixes an issue where the pack route doesn't pick up the data being sent from the group/system route resulting in empty results when a sample is processed through the pack